### PR TITLE
Fix: Ignore empty lines in data/timely-log.txt

### DIFF
--- a/src/Storage/File.php
+++ b/src/Storage/File.php
@@ -217,6 +217,9 @@ class File implements StorageInterface
 
             // move some bookings into the past to get the startbooking of a potential task we might need
             for ($i = $bookingKey + 1; $i < count($rawEntries); $i++) {
+                if (empty(trim($rawEntries[$i]))) {
+                    continue;
+                }
                 $entry = explode(self::SEPARATOR, trim($rawEntries[$i], ' |'));
                 $comment = isset($entry[2]) ? $entry[2] : '';
                 $booking = BookingFactory::getBooking($comment, $entry[1], $entry[0]);


### PR DESCRIPTION
Follow php notice if last line is empty in timely-log.txt (cause you edit nano or vi)

PHP Notice:  Undefined offset: 1 in /.../timely/src/Storage/File.php on line 225
Notice: Undefined offset: 1 in /.../timely/src/Storage/File.php on line 225